### PR TITLE
Fixes needed to get pdf format working with JtR test vectors

### DIFF
--- a/src/hashinterface.h
+++ b/src/hashinterface.h
@@ -32,7 +32,7 @@
 #define HASHKILL_VERSION PACKAGE_VERSION		// hashkill version
 #define HASHKILL_MAXTHREADS (unsigned int)128		// maximum threads
 #define HASHKILL_MAXQUEUESIZE 128 			// maximum queue size
-#define HASHFILE_MAX_LINE_LENGTH 256			// maximum line length
+#define HASHFILE_MAX_LINE_LENGTH 4096			// maximum line length
 #define HASHFILE_MAX_PLAIN_LENGTH 128
 #define VECTORSIZE 128
 #define THREAD_LENPROVIDED 1000

--- a/src/plugins/pdf.c
+++ b/src/plugins/pdf.c
@@ -77,38 +77,52 @@ char *hash_plugin_detailed(void)
 	    "\nAuthor: Dhiru Kholia <dhiru at openwall.com>\n");
 }
 
-
 hash_stat hash_plugin_parse_hash(char *hashline, char *filename)
 {
 
 	char *ctcopy = strdup(hashline);
 	char *keeptr = ctcopy;
 	char *p;
-	p = strtok(ctcopy, ":");
-	strcpy(myfilename, p);
-	p = strtok(NULL, "*");
-	cs.V = atoi(p);
-	p = strtok(NULL, "*");
-	cs.R = atoi(p);
-	p = strtok(NULL, "*");
-	cs.length = atoi(p);
-	p = strtok(NULL, "*");
-	cs.P = atoi(p);
-	p = strtok(NULL, "*");
-	cs.encrypt_metadata = atoi(p);
-	p = strtok(NULL, "*");
-	cs.length_id = atoi(p);
-	p = strtok(NULL, "*");
-	hex2str((char *) cs.id, p, cs.length_id);
-	p = strtok(NULL, "*");
-	cs.length_u = atoi(p);
-	p = strtok(NULL, "*");
-	hex2str((char *) cs.u, p, cs.length_u);
-	p = strtok(NULL, "*");
-	cs.length_o = atoi(p);
-	p = strtok(NULL, "*");
-	hex2str((char *) cs.o, p, cs.length_o);
 
+	if ((p = strtok(ctcopy, ":")) == NULL)
+		goto err;
+	strcpy(myfilename, p);
+	if ((p = strtok(NULL, "*")) == NULL)
+		goto err;
+	if (strncmp(p, "$pdf$", 5) != 0)
+		goto err;
+	p += 5;
+	cs.V = atoi(p);
+	if ((p = strtok(NULL, "*")) == NULL)
+		goto err;
+	cs.R = atoi(p);
+	if ((p = strtok(NULL, "*")) == NULL)
+		goto err;
+	cs.length = atoi(p);
+	if ((p = strtok(NULL, "*")) == NULL)
+		goto err;
+	cs.P = atoi(p);
+	if ((p = strtok(NULL, "*")) == NULL)
+		goto err;
+	cs.encrypt_metadata = atoi(p);
+	if ((p = strtok(NULL, "*")) == NULL)
+		goto err;
+	cs.length_id = atoi(p);
+	if ((p = strtok(NULL, "*")) == NULL)
+		goto err;
+	hex2str((char *) cs.id, p, cs.length_id * 2);
+	if ((p = strtok(NULL, "*")) == NULL)
+		goto err;
+	cs.length_u = atoi(p);
+	if ((p = strtok(NULL, "*")) == NULL)
+		goto err;
+	hex2str((char *) cs.u, p, cs.length_u);
+	if ((p = strtok(NULL, "*")) == NULL)
+		goto err;
+	cs.length_o = atoi(p);
+	if ((p = strtok(NULL, "*")) == NULL)
+		goto err;
+	hex2str((char *) cs.o, p, cs.length_o * 2);
 	free(keeptr);
 
 	(void) hash_add_username(myfilename);
@@ -116,6 +130,9 @@ hash_stat hash_plugin_parse_hash(char *hashline, char *filename)
 	(void) hash_add_salt("123");
 	(void) hash_add_salt2("                              ");
 	return hash_ok;
+err:
+	free(keeptr);
+	return hash_err;
 }
 
 static const unsigned char padding[32] = {


### PR DESCRIPTION
These fixes are needed to get pdf format working with JtR test vectors. I misunderstood how hex2str worked earlier. Hopefully this patch fixes all the existing problems. Also, we now reject truncated hashes instead of crashing.

Please review and pull.

Test Vectors: https://github.com/magnumripper/JohnTheRipper/blob/unstable-jumbo/src/unused/pdfdump

Passwords used are: openwall, testpassword, password

Passwords are embedded in the file names themselves. 
